### PR TITLE
Change migration of EmployeeSalary

### DIFF
--- a/database/migrations/2017_03_18_001905_create_employee_salary_table.php
+++ b/database/migrations/2017_03_18_001905_create_employee_salary_table.php
@@ -16,7 +16,7 @@ class CreateEmployeeSalaryTable extends Migration
         Schema::create('employee_salary', function (Blueprint $table) {
             $table->increments('id', true);
             $table->integer('employee_id')->unsigned();
-            $table->foreign('employee_id')->references('id')->on('employee');
+            $table->foreign('employee_id')->references('id')->on('employees');
             $table->decimal('salary', 16, 2);
             $table->timestamps();
             $table->softDeletes();


### PR DESCRIPTION
In the field for foreign key , there was a typo mistake for table name employees. So, artisan migrate was in trouble.